### PR TITLE
Fix interactable cost scaling

### DIFF
--- a/Aerolt.sln
+++ b/Aerolt.sln
@@ -6,11 +6,14 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		DebugOutDir|Any CPU = DebugOutDir|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.DebugOutDir|Any CPU.ActiveCfg = DebugOutDir|Any CPU
+		{2B1CEEC0-0D2D-4DC9-A2EF-C1DFA9BF604F}.DebugOutDir|Any CPU.Build.0 = DebugOutDir|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Aerolt/Aerolt.csproj
+++ b/Aerolt/Aerolt.csproj
@@ -5,6 +5,8 @@
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>disable</Nullable>
         <LangVersion>9</LangVersion>
+        <Configurations>Debug;Release;DebugOutDir</Configurations>
+        <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,5 +27,8 @@
         <HintPath>..\websocket-sharp.dll</HintPath>
       </Reference>
     </ItemGroup>
-
+    
+    <PropertyGroup Condition=" '$(Configuration)' == 'DebugOutDir' ">
+        <OutDir>C:\Users\$(USERNAME)\AppData\Roaming\r2modmanPlus-local\RiskOfRain2\profiles\dev\BepInEx\plugins\Lodington-Aerolt</OutDir>
+    </PropertyGroup>
 </Project>

--- a/Aerolt/Managers/InteractableManager.cs
+++ b/Aerolt/Managers/InteractableManager.cs
@@ -24,6 +24,7 @@ namespace Aerolt.Managers
         public TMP_InputField searchFilter;
         private MenuInfo _info;
         private readonly Dictionary<SpawnCard, CustomButton> cardDefRef = new();
+        static bool isScalingInteractablePricesConstantly = false;
 
         static InteractableManager()
         {
@@ -102,18 +103,25 @@ namespace Aerolt.Managers
         public static void Spawn(uint index, Vector3 position)
         {
             var spawnCard = cards[index];
-            spawnCard.DoSpawn(position, new Quaternion(), new DirectorSpawnRequest(
-                spawnCard,
-                new DirectorPlacementRule
-                {
-                    placementMode = DirectorPlacementRule.PlacementMode.NearestNode,
-                    maxDistance = 100f,
-                    minDistance = 20f,
-                    position = position,
-                    preventOverhead = true
-                },
-                RoR2Application.rng)
-            );
+            var placementRule = new DirectorPlacementRule
+            {
+                placementMode = DirectorPlacementRule.PlacementMode.NearestNode,
+                maxDistance = 30f,
+                minDistance = 10f,
+                position = position,
+                preventOverhead = true
+            };
+            var directorSpawnRequest = new DirectorSpawnRequest(spawnCard, placementRule, RoR2Application.rng);
+            var interactableObject = DirectorCore.instance.TrySpawnObject(directorSpawnRequest);
+            
+            if (!interactableObject) return;
+            var purchaseInteraction = interactableObject.GetComponent<PurchaseInteraction>();
+            if (purchaseInteraction && purchaseInteraction.costType == CostTypeIndex.Money)
+            {
+                purchaseInteraction.Networkcost = isScalingInteractablePricesConstantly
+                    ? Run.instance.GetDifficultyScaledCost(purchaseInteraction.cost)
+                    : startOfRoundScaledInteractableCosts[spawnCard];
+            }
         }
 
         private void FilterUpdated(string text)

--- a/Aerolt/Managers/InteractableManager.cs
+++ b/Aerolt/Managers/InteractableManager.cs
@@ -61,10 +61,11 @@ namespace Aerolt.Managers
                 cardDefRef[card] = buttonComponet;
                 
                 var prefab = card.prefab;
-                PurchaseInteraction purchaseInteraction = prefab.GetComponent<PurchaseInteraction>();
+                var purchaseInteraction = prefab.GetComponent<PurchaseInteraction>();
                 if (purchaseInteraction && purchaseInteraction.costType == CostTypeIndex.Money)
                 {
-                    startOfRoundScaledInteractableCosts.Add(card, Run.instance.GetDifficultyScaledCost(purchaseInteraction.cost));
+                    var scaledCost = Run.instance.GetDifficultyScaledCost(purchaseInteraction.cost);
+                    startOfRoundScaledInteractableCosts.Add(card, scaledCost);
                 }
             }
 

--- a/Aerolt/Managers/InteractableManager.cs
+++ b/Aerolt/Managers/InteractableManager.cs
@@ -38,10 +38,13 @@ namespace Aerolt.Managers
             .Select(x => x.spawnCard).Union(FindObjectOfType<SceneDirector>().GenerateInteractableCardSelection()
                 .choices.Where(x => x.value != null && x.value.spawnCard != null).Select(x => x.value.spawnCard))
             .ToArray();
-
+        
+        public static Dictionary<SpawnCard, int> startOfRoundScaledInteractableCosts = new Dictionary<SpawnCard, int>();
+        
         public void ModuleStart()
         {
             _info = GetComponentInParent<MenuInfo>();
+            startOfRoundScaledInteractableCosts.Clear();
             foreach (var card in cards.OrderBy(x =>
                 x.prefab.GetComponentInChildren<IDisplayNameProvider>() != null
                     ? x.prefab.GetComponentInChildren<IDisplayNameProvider>().GetDisplayName()
@@ -56,6 +59,13 @@ namespace Aerolt.Managers
                 buttonComponet.image.sprite = PingIndicator.GetInteractableIcon(card.prefab);
                 buttonComponet.button.onClick.AddListener(() => SpawnInteractable(card));
                 cardDefRef[card] = buttonComponet;
+                
+                var prefab = card.prefab;
+                PurchaseInteraction purchaseInteraction = prefab.GetComponent<PurchaseInteraction>();
+                if (purchaseInteraction && purchaseInteraction.costType == CostTypeIndex.Money)
+                {
+                    startOfRoundScaledInteractableCosts.Add(card, Run.instance.GetDifficultyScaledCost(purchaseInteraction.cost));
+                }
             }
 
             if (searchFilter)


### PR DESCRIPTION
Currently Aerolt does not scale the prices of interactables when spawned in the game. I have fixed this and left the code open to further customization, such as "constant scaling" button, "custom price" field, etc.